### PR TITLE
[nemo-qml-plugin-dbus] Don't add the array size to the list of dbusArguments

### DIFF
--- a/src/declarativedbusinterface.cpp
+++ b/src/declarativedbusinterface.cpp
@@ -121,6 +121,9 @@ void DeclarativeDBusInterface::call(const QString &method, const QScriptValue &a
         QJSValueIterator it(arguments);
         while (it.hasNext()) {
             it.next();
+            // Arrays carry the size as last value
+            if (!it.hasNext())
+                continue;
             dbusArguments.append(it.value().toVariant());
         }
 #else


### PR DESCRIPTION
QScriptValue arrays carry the size as last element, when a iterator
is used the size is reported as a value.
