### PR TITLE
[nemo-qml-plugin-dbus] Fix parsing of dbus introspection xml.

### DIFF
--- a/src/declarativedbusinterface.cpp
+++ b/src/declarativedbusinterface.cpp
@@ -497,8 +497,8 @@ void DeclarativeDBusInterface::connectSignalHandlerCallback(const QString &intro
 
             if (xml.name() == QLatin1String("signal"))
                 dbusSignals.append(xml.attributes().value(QLatin1String("name")).toString());
-            else
-                xml.skipCurrentElement();
+
+            xml.skipCurrentElement();
         }
     }
 


### PR DESCRIPTION
Incorrectly parsing the signal elements of the dbus introspection xml
prevented connecting to some signals.
