### PR TITLE
Each D-Bus method call requires a reply

### DIFF
--- a/src/declarativedbusadaptor.cpp
+++ b/src/declarativedbusadaptor.cpp
@@ -338,8 +338,8 @@ bool DeclarativeDBusAdaptor::handleMessage(const QDBusMessage &message, const QD
                             arguments[7],
                             arguments[8],
                             arguments[9]);
-                if (retVal.isValid()) {
-                    QDBusMessage reply = message.createReply(retVal);
+                if (success) {
+                    QDBusMessage reply = retVal.isValid() ? message.createReply(retVal) : message.createReply();
                     QDBusConnection conn = DeclarativeDBus::connection(m_bus);
                     conn.send(reply);
                 }


### PR DESCRIPTION
According to the D-Bus specification,  _even if a method call has no return values, a METHOD_RETURN reply is required, so the caller will know the method was successfully processed_.
