### PR TITLE
interface: fix nested QDBusArgument in QVariant not accessible from QML

### DIFF
--- a/src/declarativedbusinterface.cpp
+++ b/src/declarativedbusinterface.cpp
@@ -376,10 +376,15 @@ QVariant DeclarativeDBusInterface::getProperty(const QString &name)
         return QVariant();
 
     QVariant v = reply.arguments().first();
-    if (v.userType() == qMetaTypeId<QDBusVariant>())
-        return v.value<QDBusVariant>().variant();
-    else
+    if (v.userType() == qMetaTypeId<QDBusVariant>()) {
+        QVariant arg = v.value<QDBusVariant>().variant();
+        if (arg.userType() == qMetaTypeId<QDBusArgument>())
+            return parse(arg.value<QDBusArgument>());
+        else
+            return arg;
+    } else {
         return v;
+    }
 }
 
 void DeclarativeDBusInterface::setProperty(const QString &name, const QVariant &value)


### PR DESCRIPTION
The Metadata property from mpris2 Player could not be read from QML because the returned type was QVariant(QDBusArgument) this fixes that case. I think the same happens if a instead of calling getProperty we make a typedCall so that might need to be fixed too. This might not be the best solution someone should take a look into this.

You can test the patch with the following code.
```javascript
DBusInterface {
    id: mpris2
    service: "org.mpris.MediaPlayer2.spotify"
    iface: "org.mpris.MediaPlayer2.Player"
    path: "/org/mpris/MediaPlayer2"
    Component.onCompleted: {
        console.log("Property: " + getProperty('PlaybackStatus'))
        var metadata = getProperty('Metadata');
        for (var prop in metadata)
            console.log(prop, "=", metadata[prop])
    }
}
```