### PR TITLE
[nemo-qml-plugin-dbus] Improve typedCall error handling

### DIFF
--- a/src/declarativedbusinterface.h
+++ b/src/declarativedbusinterface.h
@@ -72,7 +72,7 @@ public:
     void setSignalsEnabled(bool enabled);
 
     Q_INVOKABLE void call(const QString &method, const QJSValue &arguments);
-    Q_INVOKABLE void typedCall(const QString &method, const QJSValue &arguments,
+    Q_INVOKABLE bool typedCall(const QString &method, const QJSValue &arguments,
             const QJSValue &callback=QJSValue::UndefinedValue,
             const QJSValue &errorCallback=QJSValue::UndefinedValue);
 


### PR DESCRIPTION
Make typedCall return false if it fails to initiate the dbus call, true otherwise. The return value indicates whether the caller of typedCall can expect a callback function or not.