### PR TITLE
[nemo-qml-plugin-dbus] Added signal for property changes via DBus properties

### DIFF
--- a/src/declarativedbusinterface.cpp
+++ b/src/declarativedbusinterface.cpp
@@ -39,6 +39,10 @@
 #include <QUrl>
 #include <QXmlStreamReader>
 
+namespace {
+const QLatin1String PropertyInterface("org.freedesktop.DBus.Properties");
+}
+
 DeclarativeDBusInterface::DeclarativeDBusInterface(QObject *parent)
 :   QObject(parent), m_bus(DeclarativeDBus::SessionBus), m_componentCompleted(false), m_signalsEnabled(false)
 {
@@ -365,7 +369,7 @@ QVariant DeclarativeDBusInterface::getProperty(const QString &name)
 {
     QDBusMessage message =
         QDBusMessage::createMethodCall(m_service, m_path,
-                                       QLatin1String("org.freedesktop.DBus.Properties"),
+                                       PropertyInterface,
                                        QLatin1String("Get"));
 
     QVariantList args;
@@ -397,8 +401,8 @@ QVariant DeclarativeDBusInterface::getProperty(const QString &name)
 void DeclarativeDBusInterface::setProperty(const QString &name, const QVariant &value)
 {
     QDBusMessage message = QDBusMessage::createMethodCall(m_service, m_path,
-            QLatin1String("org.freedesktop.DBus.Properties"),
-            QLatin1String("Set"));
+                                                          PropertyInterface,
+                                                          QLatin1String("Set"));
 
     QVariantList args;
     args.append(m_interface);
@@ -485,6 +489,7 @@ void DeclarativeDBusInterface::signalHandler(const QDBusMessage &message)
 void DeclarativeDBusInterface::connectSignalHandlerCallback(const QString &introspectionData)
 {
     QStringList dbusSignals;
+    bool connectPropertyInterface = false;
 
     QXmlStreamReader xml(introspectionData);
     while (!xml.atEnd()) {
@@ -494,8 +499,17 @@ void DeclarativeDBusInterface::connectSignalHandlerCallback(const QString &intro
         if (xml.name() == QLatin1String("node"))
             continue;
 
-        if (xml.name() != QLatin1String("interface") ||
-            xml.attributes().value(QLatin1String("name")) != m_interface) {
+        bool skip = false;
+        if (xml.name() != QLatin1String("interface")) {
+            skip = true;
+        } else if (xml.attributes().value(QLatin1String("name")) == PropertyInterface) {
+            connectPropertyInterface = true;
+            skip = true;
+        } else if (xml.attributes().value(QLatin1String("name")) != m_interface) {
+            skip = true;
+        }
+
+        if (skip) {
             xml.skipCurrentElement();
             continue;
         }
@@ -511,7 +525,7 @@ void DeclarativeDBusInterface::connectSignalHandlerCallback(const QString &intro
         }
     }
 
-    if (dbusSignals.isEmpty())
+    if (dbusSignals.isEmpty() && !connectPropertyInterface)
         return;
 
     QDBusConnection conn = DeclarativeDBus::connection(m_bus);
@@ -556,6 +570,20 @@ void DeclarativeDBusInterface::connectSignalHandlerCallback(const QString &intro
         if (dbusSignals.isEmpty())
             break;
     }
+
+    if (connectPropertyInterface) {
+        bool success = conn.connect(m_service, m_path, PropertyInterface, QLatin1String("PropertiesChanged"),
+                                    "sa{sv}as", this, SLOT(notifyPropertyChange()));
+        if (!success) {
+            qmlInfo(this) << "Failed to connect to DBus property interface signaling, service: "
+                          << m_service << " path: " << m_path;
+        }
+    }
+}
+
+void DeclarativeDBusInterface::notifyPropertyChange()
+{
+    emit propertiesChanged();
 }
 
 void DeclarativeDBusInterface::disconnectSignalHandler()

--- a/src/declarativedbusinterface.h
+++ b/src/declarativedbusinterface.h
@@ -91,11 +91,13 @@ signals:
     void interfaceChanged();
     void busChanged();
     void signalsEnabledChanged();
+    void propertiesChanged();
 
 private slots:
     void pendingCallFinished(QDBusPendingCallWatcher *watcher);
     void signalHandler(const QDBusMessage &message);
     void connectSignalHandlerCallback(const QString &introspectionData);
+    void notifyPropertyChange();
 
 private:
     void disconnectSignalHandler();


### PR DESCRIPTION

Signal propertiesChanged() is emitted when remote DBus object's
properties with org.freedesktop.DBus.Properties interface are changed.